### PR TITLE
Adds config to disable unused fields and widgets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,34 @@ Usage:
 <a href="{{ actionUrl('tools/tools/download-file', { id: entry.assetField.one().id }) }}">Download</a>
 ```
 
+
+## Configuration
+
+By default, all normal field types and widgets are enabled. 
+The commerce field types are only enabled if Craft Commerce is installed and enabled.
+You can disable each field type and widget by adding the following to your project's `config/tools.php` file:
+
+```php
+use spicyweb\oddsandends\fields\AuthorInstructions;
+use spicyweb\oddsandends\fields\DisabledProducts;
+use spicyweb\oddsandends\widgets\RollYourOwn;
+
+return [
+    'disableNormalFields' => [
+        AuthorInstructions::class,
+    ],
+    'disableCommerceFields' => [
+        DisabledProducts::class,
+    ],
+    'disableWidgets' => [
+        RollYourOwn::class,
+    ],
+];
+```
+
+Multi environment config is supported. See [Craft's docs](https://craftcms.com/docs/4.x/config/#multi-environment-configs) for more info.
+See `config/tools.php` in this repo for an example that disables all fields and widgets.
+
 ---
 
 *Created by [Supercool](https://supercooldesign.co.uk)*

--- a/config/tools.php
+++ b/config/tools.php
@@ -1,0 +1,56 @@
+<?php
+
+// use spicyweb\oddsandends\fields\Ancestors;
+// use spicyweb\oddsandends\fields\AuthorInstructions;
+// use spicyweb\oddsandends\fields\CategoriesMultipleGroups;
+// use spicyweb\oddsandends\fields\CategoriesSearch;
+// use spicyweb\oddsandends\fields\DisabledCategories;
+// use spicyweb\oddsandends\fields\DisabledDropdown;
+// use spicyweb\oddsandends\fields\DisabledEntries;
+// use spicyweb\oddsandends\fields\DisabledLightswitch;
+// use spicyweb\oddsandends\fields\DisabledNumber;
+// use spicyweb\oddsandends\fields\DisabledPlainText;
+// use spicyweb\oddsandends\fields\DisabledProducts;
+// use spicyweb\oddsandends\fields\DisabledVariants;
+// use spicyweb\oddsandends\fields\EntriesSearch;
+// use spicyweb\oddsandends\fields\Grid;
+// use spicyweb\oddsandends\fields\ProductsSearch;
+// use spicyweb\oddsandends\fields\VariantsSearch;
+// use spicyweb\oddsandends\fields\Width;
+// use spicyweb\oddsandends\widgets\RollYourOwn;
+
+/*
+ * This is an example of project specific configuration for Odds and Ends.
+ * You can disable any of the Odds and Ends fields and widgets by adding them below.
+ * Copy this file to your project's config directory and uncomment the fields and widgets you want to disable.
+ * Remember to also uncomment the use statements above.
+ *
+ * Multi environment config is possible, see:
+ * https://craftcms.com/docs/4.x/extend/plugin-settings.html#overriding-setting-values
+ * */
+return [
+    'disableNormalFields' => [
+        // AuthorInstructions::class,
+        // DisabledLightswitch::class,
+        // DisabledPlainText::class,
+        // DisabledNumber::class,
+        // DisabledEntries::class,
+        // DisabledCategories::class,
+        // DisabledDropdown::class,
+        // EntriesSearch::class,
+        // CategoriesSearch::class,
+        // CategoriesMultipleGroups::class,
+        // Width::class,
+        // Ancestors::class,
+        // Grid::class,
+    ],
+    'disableCommerceFields' => [
+        // DisabledProducts::class,
+        // DisabledVariants::class,
+        // ProductsSearch::class,
+        // VariantsSearch::class,
+    ],
+    'disableWidgets' => [
+        // RollYourOwn::class,
+    ],
+];

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -64,36 +64,63 @@ class Tools extends Plugin
             Fields::className(),
             Fields::EVENT_REGISTER_FIELD_TYPES,
             function(RegisterComponentTypesEvent $event) {
-                $event->types[] = AuthorInstructionsField::class;
-                $event->types[] = DisabledLightswitchField::class;
-                $event->types[] = DisabledPlainTextField::class;
-                $event->types[] = DisabledNumberField::class;
-                $event->types[] = DisabledEntriesField::class;
-                $event->types[] = DisabledCategoriesField::class;
-                $event->types[] = DisabledDropdownField::class;
-                $event->types[] = EntriesSearchField::class;
-                $event->types[] = CategoriesSearchField::class;
-                $event->types[] = CategoriesMultipleGroupsField::class;
-                $event->types[] = WidthField::class;
-                $event->types[] = AncestorsField::class;
-                $event->types[] = GridField::class;
+                $enableNormalFields = [
+                    AuthorInstructionsField::class,
+                    DisabledLightswitchField::class,
+                    DisabledPlainTextField::class,
+                    DisabledNumberField::class,
+                    DisabledEntriesField::class,
+                    DisabledCategoriesField::class,
+                    DisabledDropdownField::class,
+                    EntriesSearchField::class,
+                    CategoriesSearchField::class,
+                    CategoriesMultipleGroupsField::class,
+                    WidthField::class,
+                    AncestorsField::class,
+                    GridField::class,
+                ];
+
+                $enableNormalFields = array_diff($enableNormalFields, $this->settings->disableNormalFields);
+                Craft::debug($this->name.' enable normal fields: ' . implode(', ', $enableNormalFields), __METHOD__);
+
+                foreach ($enableNormalFields as $field) {
+                    $event->types[] = $field;
+                }
 
                 $pluginsService = Craft::$app->getPlugins();
                 if ($pluginsService->isPluginInstalled('commerce') && $pluginsService->isPluginEnabled('commerce')) {
-                    $event->types[] = DisabledProductsField::class;
-                    $event->types[] = DisabledVariantsField::class;
-                    $event->types[] = ProductsSearchField::class;
-                    $event->types[] = VariantsSearchField::class;
+                    $enableCommerceFields = [
+                        DisabledProductsField::class,
+                        DisabledVariantsField::class,
+                        ProductsSearchField::class,
+                        VariantsSearchField::class,
+                    ];
+
+                    $enableCommerceFields = array_diff($enableCommerceFields, $this->settings->disableCommerceFields);
+                    Craft::debug($this->name.' enable commerce fields: ' . implode(', ', $enableCommerceFields), __METHOD__);
+
+                    foreach ($enableCommerceFields as $field) {
+                        $event->types[] = $field;
+                    }
                 }
             }
         );
 
-        // Register the Roll Your Own Widget
+        // Register widgets
         Event::on(
             Dashboard::className(),
             Dashboard::EVENT_REGISTER_WIDGET_TYPES,
             function(RegisterComponentTypesEvent $event) {
-                $event->types[] = RollYourOwnWidget::class;
+                $enableWidgets = [
+                    RollYourOwnWidget::class,
+                ];
+
+                $enableWidgets = array_diff($enableWidgets, $this->settings->disableWidgets);
+                Craft::debug($this->name.' enable widgets: ' . implode(', ', $enableWidgets), __METHOD__);
+
+                foreach ($enableWidgets as $widget) {
+                    $event->types[] = $widget;
+                }
             }
         );
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -14,6 +14,10 @@ use craft\base\Model;
  */
 class Settings extends Model
 {
+    public array $disableNormalFields = [];
+    public array $disableCommerceFields = [];
+    public array $disableWidgets = [];
+
     /**
      * @var int
      */


### PR DESCRIPTION
As discussed in #24, this is a PR to add config to disable each field and widget if you don't want to load parts of the plugin you don't use.

Tested on Craft Pro 4.4.4, PHP 8.2.3.

Question:

Should I also a cleanup of the old settings?
```
    /**
     * @var int
     */
    public int $leftDefault = 0;

    /**
     * @var int
     */
    public int $rightDefault = 0;

    /**
     * @inheritdoc
     */
    protected function defineRules(): array
    {
        return [
            [['leftDefault', 'rightDefault'], 'required'],
        ];
    }
```
I don't think they've been used since: https://github.com/spicywebau/craft-odds-and-ends/commit/f03400f3be9a1fbe1ce65b0908b3c8d31994b3e7