### PR TITLE
Migration for supercool fields -> spicyweb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "spicyweb/craft-odds-and-ends",
     "description": "A collection of useful tools for Craft CMS websites",
     "type": "craft-plugin",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "keywords": [
         "craft",
         "cms",
@@ -31,7 +31,7 @@
     "extra": {
         "name": "Odds & Ends",
         "handle": "tools",
-        "schemaVersion": "3.0.0",
+        "schemaVersion": "3.0.3",
         "hasCpSettings": false,
         "hasCpSection": false,
         "changelogUrl": "https://raw.githubusercontent.com/spicywebau/craft-odds-and-ends/master/CHANGELOG.md",

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -44,6 +44,11 @@ class Tools extends Plugin
     /**
      * @inheritdoc
      */
+    public string $schemaVersion = '3.0.3';
+
+    /**
+     * @inheritdoc
+     */
     public function init()
     {
         parent::init();

--- a/src/migrations/m230911_000000_supercool_fields_migration.php
+++ b/src/migrations/m230911_000000_supercool_fields_migration.php
@@ -1,0 +1,50 @@
+<?php
+namespace spicyweb\oddsandends\migrations;
+
+use spicyweb\oddsandends\fields\Ancestors;
+use spicyweb\oddsandends\fields\AuthorInstructions;
+use spicyweb\oddsandends\fields\CategoriesMultipleGroups;
+use spicyweb\oddsandends\fields\CategoriesSearch;
+use spicyweb\oddsandends\fields\DisabledCategories;
+use spicyweb\oddsandends\fields\DisabledDropdown;
+use spicyweb\oddsandends\fields\DisabledEntries;
+use spicyweb\oddsandends\fields\DisabledLightswitch;
+use spicyweb\oddsandends\fields\DisabledNumber;
+use spicyweb\oddsandends\fields\DisabledPlainText;
+use spicyweb\oddsandends\fields\EntriesSearch;
+use spicyweb\oddsandends\fields\Grid;
+use spicyweb\oddsandends\fields\Width;
+
+use Craft;
+use craft\db\Migration;
+
+class m230911_000000_supercool_fields_migration extends Migration
+{
+    // Public Methods
+    // =========================================================================
+
+    public function safeUp(): bool
+    {
+        $this->update('{{%fields}}', ['type' => Ancestors::class], ['type' => 'supercool\tools\fields\Ancestors']);
+        $this->update('{{%fields}}', ['type' => AuthorInstructions::class], ['type' => 'supercool\tools\fields\AuthorInstructions']);
+        $this->update('{{%fields}}', ['type' => CategoriesMultipleGroups::class], ['type' => 'supercool\tools\fields\CategoriesMultipleGroups']);
+        $this->update('{{%fields}}', ['type' => CategoriesSearch::class], ['type' => 'supercool\tools\fields\CategoriesSearch']);
+        $this->update('{{%fields}}', ['type' => DisabledCategories::class], ['type' => 'supercool\tools\fields\DisabledCategories']);
+        $this->update('{{%fields}}', ['type' => DisabledDropdown::class], ['type' => 'supercool\tools\fields\DisabledDropdown']);
+        $this->update('{{%fields}}', ['type' => DisabledEntries::class], ['type' => 'supercool\tools\fields\DisabledEntries']);
+        $this->update('{{%fields}}', ['type' => DisabledLightswitch::class], ['type' => 'supercool\tools\fields\DisabledLightswitch']);
+        $this->update('{{%fields}}', ['type' => DisabledNumber::class], ['type' => 'supercool\tools\fields\DisabledNumber']);
+        $this->update('{{%fields}}', ['type' => DisabledPlainText::class], ['type' => 'supercool\tools\fields\DisabledPlainText']);
+        $this->update('{{%fields}}', ['type' => EntriesSearch::class], ['type' => 'supercool\tools\fields\EntriesSearch']);
+        $this->update('{{%fields}}', ['type' => Grid::class], ['type' => 'supercool\tools\fields\Grid']);
+        $this->update('{{%fields}}', ['type' => Width::class], ['type' => 'supercool\tools\fields\Width']);
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        echo "m230911_000000_supercool_fields_migration cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
Hi,

I've recently joined SuperCool, and I am upgrading some of our older projects. These are still on Craft 3, and when I migrate them from supercool/tools to spicyweb/craft-odds-and-ends, the fields are not migrated.

These projects are not using Project Config, and so I do not believe /src/migrations/m220921_060212_update_developer_in_db.php covers this scenario, hence why I've had to run the attached migration manually.

It would be a big help if we could get this approved in helping us migrate to the plugin you now maintain (possibly adding this to your 4.x branch also to keep things consistent, especially with schemaVersions, etc.?)

Thanks,
Jamie (Supercool)