### PR TITLE
schemaVersion must not be defined error

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -44,7 +44,7 @@ class Tools extends Plugin
     /**
      * @inheritdoc
      */
-    public string $schemaVersion = '3.0.3';
+    public $schemaVersion = '3.0.3';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
When updating this plugin, we got a "schemaVersion must not be defined" error (big apologies). Made a PR for the fix for a 3.0.3.1 update